### PR TITLE
feat: implement default rate limiter with exponential timeout

### DIFF
--- a/pkg/plugins/workload/v1/scaffolds/templates/controller/controller.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/controller/controller.go
@@ -120,9 +120,9 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	if len(collectionList.Items) == 0 {
 		log.V(0).Info("no collections available - will try again in 10 seconds")
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		return ctrl.Result{Requeue: true}, nil
 	} else if len(collectionList.Items) > 1 {
-		log.V(0).Info("multiple collections found - cannot proceded")
+		log.V(0).Info("multiple collections found - cannot proceed")
 		return ctrl.Result{}, nil
 	}
 	r.Collection = &collectionList.Items[0]
@@ -135,7 +135,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 		// return only if we have an error or are told not to proceed
 		if err != nil || !proceed {
-			log.V(0).Info(fmt.Sprintf("Not proceeding - will try again in %s", result.RequeueAfter))
+			log.V(4).Info("not proceeding - requeuing")
 			return result, err
 		}
 	}

--- a/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/complete.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/complete.go
@@ -63,9 +63,9 @@ func (phase *CompletePhase) GetFailCondition() common.Condition {
 	}
 }
 
-// GetDefaultRequeueResult defines the result return when a requeue is needed
-func (phase *CompletePhase) GetDefaultRequeueResult() ctrl.Result {
-	return DefaultRequeueResult()
+// Requeue defines the result return when a requeue is needed
+func (phase *CompletePhase) Requeue() ctrl.Result {
+	return Requeue()
 }
 
 // CompletePhase.Execute executes the completion of a reconciliation loop

--- a/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/resource_persist.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/resource_persist.go
@@ -60,19 +60,17 @@ func (phase *PersistResourcePhase) Execute(
 		for _, replacedResource := range resource.ReplacedResources {
 			err := persistResource(resource.ComponentReconciler, replacedResource)
 			if err != nil {
-				if isOptimisticLockError(err) {
-					return ctrl.Result{RequeueAfter: time.Second * 1}, true, nil
+				if !isOptimisticLockError(err) {
+					return ctrl.Result{}, false, err
 				}
-				return ctrl.Result{}, false, err
 			}
 		}
 	} else {
 		err := persistResource(resource.ComponentReconciler, *resource.OriginalResource)
 		if err != nil {
-			if isOptimisticLockError(err) {
-				return ctrl.Result{RequeueAfter: time.Second * 1}, true, nil
+			if !isOptimisticLockError(err) {
+				return ctrl.Result{}, false, err
 			}
-			return ctrl.Result{}, false, err
 		}
 	}
 

--- a/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/resource_wait.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/resource_wait.go
@@ -40,7 +40,7 @@ import (
 
 // defaultWaitRequeue defines the default requeue result for this phase
 func defaultWaitRequeue() ctrl.Result {
-	return ctrl.Result{RequeueAfter: 3 * time.Second}
+	return ctrl.Result{Requeue: true}
 }
 
 // WaitForResourcePhase.Execute executes waiting for a resource to be ready before continuing

--- a/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/types.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/controller/phases/types.go
@@ -46,7 +46,7 @@ type PhaseHandler interface {
 	GetSuccessCondition() common.Condition
 	GetPendingCondition() common.Condition
 	GetFailCondition() common.Condition
-	GetDefaultRequeueResult() ctrl.Result
+	Requeue() ctrl.Result
 }
 
 // ResourcePhase defines the specific phase of reconcilication associated with creating resources


### PR DESCRIPTION
Use default Rate Limiter for Requeue Requests, initial failures requeue with a a per-item exponential back-off starting at 5ms to a max of 1000 seconds and rate.NewLimiter(10, 100) (i.e. rate limit of 10 per second and burst amount of 100)

Signed-off-by: Jeff Davis <jeffda@vmware.com>