### PR TITLE
fix: correct APISpecContent spelling in template

### DIFF
--- a/pkg/plugins/workload/v1/scaffolds/templates/api/types.go
+++ b/pkg/plugins/workload/v1/scaffolds/templates/api/types.go
@@ -85,7 +85,7 @@ type {{ .Resource.Kind }}Spec struct {
 		{{- range .DocumentationLines }}
 			// {{ . -}}
 		{{ end }}
-		{{ .ApiSpecContent }}
+		{{ .APISpecContent }}
 	{{ end }}
 }
 


### PR DESCRIPTION
Signed-off-by: Jeff Davis <jeffda@vmware.com>