### PR TITLE
feat: fixes #84 by adding stub phases to controller

### DIFF
--- a/internal/plugins/workload/v1/scaffolds/api.go
+++ b/internal/plugins/workload/v1/scaffolds/api.go
@@ -26,6 +26,10 @@ import (
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/dependencies"
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/helpers"
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/mutate"
+	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/postcreate"
+	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/postflight"
+	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/precreate"
+	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/preflight"
 	resourcespkg "github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/resources"
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/int/wait"
 	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
@@ -241,6 +245,9 @@ func (s *apiScaffolder) Scaffold() error {
 			&phases.ResourcePersist{},
 			&phases.Dependencies{},
 			&phases.PreFlight{},
+			&phases.PostFlight{},
+			&phases.PreCreate{},
+			&phases.PostCreate{},
 			&phases.ResourceWait{},
 			&phases.CheckReady{},
 			&phases.Complete{},
@@ -249,6 +256,10 @@ func (s *apiScaffolder) Scaffold() error {
 			&dependencies.Component{},
 			&mutate.Component{},
 			&wait.Component{},
+			&preflight.Component{},
+			&postflight.Component{},
+			&precreate.Component{},
+			&postcreate.Component{},
 			&samples.CRDSample{
 				SpecFields: s.workload.GetAPISpecFields(),
 			},
@@ -315,6 +326,9 @@ func (s *apiScaffolder) Scaffold() error {
 			&phases.ResourcePersist{},
 			&phases.Dependencies{},
 			&phases.PreFlight{},
+			&phases.PostFlight{},
+			&phases.PreCreate{},
+			&phases.PostCreate{},
 			&phases.ResourceWait{},
 			&phases.CheckReady{},
 			&phases.Complete{},
@@ -323,6 +337,10 @@ func (s *apiScaffolder) Scaffold() error {
 			&dependencies.Component{},
 			&mutate.Component{},
 			&wait.Component{},
+			&preflight.Component{},
+			&postflight.Component{},
+			&precreate.Component{},
+			&postcreate.Component{},
 			&samples.CRDSample{
 				SpecFields: s.workload.GetAPISpecFields(),
 			},
@@ -389,6 +407,10 @@ func (s *apiScaffolder) Scaffold() error {
 				&mutate.Component{},
 				&helpers.Component{},
 				&wait.Component{},
+				&preflight.Component{},
+				&postflight.Component{},
+				&precreate.Component{},
+				&postcreate.Component{},
 				&samples.CRDSample{
 					SpecFields: component.Spec.APISpecFields,
 				},
@@ -455,4 +477,3 @@ func (s *apiScaffolder) Scaffold() error {
 
 	return nil
 }
-

--- a/internal/plugins/workload/v1/scaffolds/templates/api/common/components.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/api/common/components.go
@@ -86,6 +86,10 @@ type ComponentReconciler interface {
 	CheckReady() (bool, error)
 	Mutate(*metav1.Object) ([]metav1.Object, bool, error)
 	Wait(*metav1.Object) (bool, error)
+	PreFlight() (bool, error)
+	PostFlight() (bool, error)
+	PreCreate() (bool, error)
+	PostCreate() (bool, error)
 }
 
 type ComponentResource interface {
@@ -107,4 +111,3 @@ type ComponentResource interface {
 	ToCommonResource() *Resource
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/controller/controller.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/controller/controller.go
@@ -77,6 +77,10 @@ import (
 	"{{ .Repo }}/internal/mutate"
 	"{{ .Repo }}/internal/resources"
 	"{{ .Repo }}/internal/wait"
+	"{{ .Repo }}/internal/preflight"
+	"{{ .Repo }}/internal/postflight"
+	"{{ .Repo }}/internal/precreate"
+	"{{ .Repo }}/internal/postcreate"
 )
 
 // {{ .Resource.Kind }}Reconciler reconciles a {{ .Resource.Kind }} object.
@@ -357,6 +361,30 @@ func (r *{{ .Resource.Kind }}Reconciler) Wait(
 	return wait.{{ .Resource.Kind }}Wait(r, object)
 }
 
+// PreFlight performs preflight logic that happens before controller
+// reconciliation is performed.
+func (r *{{ .Resource.Kind }}Reconciler) PreFlight() (bool, error) {
+	return preflight.{{ .Resource.Kind }}PreFlight(r)
+}
+
+// PostFlight performs postflight logic that happens after controller
+// reconciliation is performed.
+func (r *{{ .Resource.Kind }}Reconciler) PostFlight() (bool, error) {
+	return postflight.{{ .Resource.Kind }}PostFlight(r)
+}
+
+// PreCreate performs precreate logic that happens before resource
+// creation is performed.
+func (r *{{ .Resource.Kind }}Reconciler) PreCreate() (bool, error) {
+	return precreate.{{ .Resource.Kind }}PreCreate(r)
+}
+
+// PostCreate performs postcreate logic that happens after resource
+// creation is performed.
+func (r *{{ .Resource.Kind }}Reconciler) PostCreate() (bool, error) {
+	return postcreate.{{ .Resource.Kind }}PostCreate(r)
+}
+
 func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	options := controller.Options{
 		RateLimiter: utils.NewDefaultRateLimiter(5*time.Microsecond, 5*time.Minute),
@@ -376,4 +404,3 @@ func (r *{{ .Resource.Kind }}Reconciler) SetupWithManager(mgr ctrl.Manager) erro
 	return nil
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/check_ready.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/check_ready.go
@@ -39,7 +39,8 @@ import (
 	"{{ .Repo }}/internal/resources"
 )
 
-// CheckReadyPhase.DefaultRequeue executes checking for a parent components readiness status.
+// CheckReadyPhase.DefaultRequeue defines the default requeue result for this
+// phase.
 func (phase *CheckReadyPhase) DefaultRequeue() ctrl.Result {
 	return ctrl.Result{
 		Requeue:      true,
@@ -51,19 +52,18 @@ func (phase *CheckReadyPhase) DefaultRequeue() ctrl.Result {
 func (phase *CheckReadyPhase) Execute(
 	r common.ComponentReconciler,
 ) (proceedToNextPhase bool, err error) {
-	// check to see if known types are ready
-	knownReady, err := resources.AreReady(r.GetResources()...)
-	if err != nil {
+	// check to see if known resource types are ready
+	resourcesAreReady, err := resources.AreReady(r.GetResources()...)
+	if err != nil || !resourcesAreReady {
 		return false, err
 	}
 
 	// check to see if the custom methods return ready
-	customReady, err := r.CheckReady()
-	if err != nil {
+	ready, err := r.CheckReady()
+	if err != nil || !ready {
 		return false, err
 	}
 
-	return (knownReady && customReady), nil
+	return true, nil
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/complete.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/complete.go
@@ -36,7 +36,8 @@ import (
 	"{{ .Repo }}/apis/common"
 )
 
-// CompletePhase.DefaultRequeue executes checking for a parent components readiness status.
+// CompletePhase.DefaultRequeue defines the default requeue result for this
+// phase.
 func (phase *CompletePhase) DefaultRequeue() ctrl.Result {
 	return Requeue()
 }
@@ -51,4 +52,3 @@ func (phase *CompletePhase) Execute(
 	return true, nil
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/create_resource.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/create_resource.go
@@ -40,7 +40,8 @@ import (
 	"{{ .Repo }}/apis/common"
 )
 
-// CreateResourcesPhase.DefaultRequeue executes checking for a parent components readiness status.
+// CreateResourcesPhase.DefaultRequeue defines the default requeue result for this
+// phase.
 func (phase *CreateResourcesPhase) DefaultRequeue() ctrl.Result {
 	return Requeue()
 }
@@ -84,4 +85,3 @@ func (phase *CreateResourcesPhase) Execute(
 	return true, nil
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/dependency.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/dependency.go
@@ -42,7 +42,8 @@ import (
 	"{{ .Repo }}/internal/helpers"
 )
 
-// DependencyPhase.DefaultRequeue executes checking for a parent components readiness status.
+// DependencyPhase.DefaultRequeue defines the default requeue result for this
+// phase.
 func (phase *DependencyPhase) DefaultRequeue() ctrl.Result {
 	return Requeue()
 }
@@ -129,4 +130,3 @@ func collectionConfigIsReady(r common.ComponentReconciler) bool {
 	return true
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/post_create.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/post_create.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package phases
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &PostCreate{}
+
+// PostCreate scaffolds the post-create phase methods.
+type PostCreate struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+}
+
+func (f *PostCreate) SetTemplateDefaults() error {
+	f.Path = filepath.Join("internal", "controllers", "phases", "post_create.go")
+
+	f.TemplateBody = postCreateTemplate
+
+	return nil
+}
+
+const postCreateTemplate = `{{ .Boilerplate }}
+
+package phases
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"{{ .Repo }}/apis/common"
+)
+
+// PostCreatePhase.DefaultRequeue defines the default requeue result for this
+// phase.
+func (phase *PostCreatePhase) DefaultRequeue() ctrl.Result {
+	return Requeue()
+}
+
+// PostCreatePhase.Execute executes the post-create stub phase after
+// resource creation has been performed.
+func (phase *PostCreatePhase) Execute(
+	r common.ComponentReconciler,
+) (proceedToNextPhase bool, err error) {
+	return r.PostCreate()
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/post_flight.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/post_flight.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package phases
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &PostFlight{}
+
+// PostFlight scaffolds the post-flight phase methods.
+type PostFlight struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+}
+
+func (f *PostFlight) SetTemplateDefaults() error {
+	f.Path = filepath.Join("internal", "controllers", "phases", "post_flight.go")
+
+	f.TemplateBody = postFlightTemplate
+
+	return nil
+}
+
+const postFlightTemplate = `{{ .Boilerplate }}
+
+package phases
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"{{ .Repo }}/apis/common"
+)
+
+// PostFlightPhase.DefaultRequeue defines the default requeue result for this
+// phase.
+func (phase *PostFlightPhase) DefaultRequeue() ctrl.Result {
+	return Requeue()
+}
+
+// PostFlightPhase.Execute executes the post-flight stub phase after
+// reconciliation has been performed.
+func (phase *PostFlightPhase) Execute(
+	r common.ComponentReconciler,
+) (proceedToNextPhase bool, err error) {
+	return r.PostFlight()
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/pre_create.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/pre_create.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package phases
+
+import (
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+)
+
+var _ machinery.Template = &PreCreate{}
+
+// PreCreate scaffolds the pre-create phase methods.
+type PreCreate struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+}
+
+func (f *PreCreate) SetTemplateDefaults() error {
+	f.Path = filepath.Join("internal", "controllers", "phases", "pre_create.go")
+
+	f.TemplateBody = preCreateTemplate
+
+	return nil
+}
+
+const preCreateTemplate = `{{ .Boilerplate }}
+
+package phases
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"{{ .Repo }}/apis/common"
+)
+
+// PreCreatePhase.DefaultRequeue defines the default requeue result for this
+// phase.
+func (phase *PreCreatePhase) DefaultRequeue() ctrl.Result {
+	return Requeue()
+}
+
+// PreCreatePhase.Execute executes the pre-create stub phase before
+// resource creation has been performed.
+func (phase *PreCreatePhase) Execute(
+	r common.ComponentReconciler,
+) (proceedToNextPhase bool, err error) {
+	return r.PreCreate()
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/pre_flight.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/pre_flight.go
@@ -36,16 +36,17 @@ import (
 	"{{ .Repo }}/apis/common"
 )
 
-// PreFlightPhase.DefaultRequeue executes checking for a parent components readiness status.
+// PreFlightPhase.DefaultRequeue defines the default requeue result for this
+// phase.
 func (phase *PreFlightPhase) DefaultRequeue() ctrl.Result {
 	return Requeue()
 }
 
-// PreFlightPhase.Execute executes pre-flight and fail-fast conditions prior to attempting resource creation.
+// PreFlightPhase.Execute executes the pre-flight stub phase before
+// reconciliation has been performed.
 func (phase *PreFlightPhase) Execute(
 	r common.ComponentReconciler,
 ) (proceedToNextPhase bool, err error) {
-	return true, nil
+	return r.PreFlight()
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/types.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/phases/types.go
@@ -52,11 +52,14 @@ type ResourcePhase interface {
 }
 
 // Below are the phase types which satisfy the Phase interface.
-type DependencyPhase struct{}
 type PreFlightPhase struct{}
+type DependencyPhase struct{}
+type PreCreatePhase struct{}
 type CreateResourcesPhase struct{}
+type PostCreatePhase struct{}
 type CheckReadyPhase struct{}
 type CompletePhase struct{}
+type PostFlightPhase struct{}
 
 // Below are the phase types which satisfy the ResourcePhase interface.
 type PersistResourcePhase struct{}
@@ -101,4 +104,3 @@ func getResourcePhaseName(resourcePhase ResourcePhase) string {
 	return objectElements[len(objectElements)-1]
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/controllers/utils/utils.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/controllers/utils/utils.go
@@ -66,11 +66,14 @@ func IgnoreNotFound(err error) error {
 // CreatePhases defines the phases for create and the order in which they run during the reconcile process.
 func CreatePhases() []controllerphases.Phase {
 	return []controllerphases.Phase{
-		&controllerphases.DependencyPhase{},
 		&controllerphases.PreFlightPhase{},
+		&controllerphases.DependencyPhase{},
+		&controllerphases.PreCreatePhase{},
 		&controllerphases.CreateResourcesPhase{},
+		&controllerphases.PostCreatePhase{},
 		&controllerphases.CheckReadyPhase{},
 		&controllerphases.CompletePhase{},
+		&controllerphases.PostFlightPhase{},
 	}
 }
 
@@ -216,4 +219,3 @@ func Watch(
 	return nil
 }
 `
-

--- a/internal/plugins/workload/v1/scaffolds/templates/int/postcreate/component.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/postcreate/component.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package postcreate
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
+)
+
+var _ machinery.Template = &Component{}
+
+// Component scaffolds the workload's postcreate function.
+type Component struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+	machinery.ResourceMixin
+}
+
+func (f *Component) SetTemplateDefaults() error {
+	f.Path = filepath.Join(
+		"internal",
+		"postcreate",
+		fmt.Sprintf("%s.go", utils.ToFileName(f.Resource.Kind)),
+	)
+
+	f.TemplateBody = componentTemplate
+
+	return nil
+}
+
+const componentTemplate = `{{ .Boilerplate }}
+
+package postcreate
+
+import (
+	"{{ .Repo }}/apis/common"
+)
+
+// {{ .Resource.Kind }}PostCreate performs postcreate logic that happens after
+// resource creation is performed.
+func {{ .Resource.Kind }}PostCreate(
+	reconciler common.ComponentReconciler,
+) (ready bool, err error) {
+	return true, nil
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/postflight/component.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/postflight/component.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package postflight
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
+)
+
+var _ machinery.Template = &Component{}
+
+// Component scaffolds the workload's postflight function.
+type Component struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+	machinery.ResourceMixin
+}
+
+func (f *Component) SetTemplateDefaults() error {
+	f.Path = filepath.Join(
+		"internal",
+		"postflight",
+		fmt.Sprintf("%s.go", utils.ToFileName(f.Resource.Kind)),
+	)
+
+	f.TemplateBody = componentTemplate
+
+	return nil
+}
+
+const componentTemplate = `{{ .Boilerplate }}
+
+package postflight
+
+import (
+	"{{ .Repo }}/apis/common"
+)
+
+// {{ .Resource.Kind }}PostFlight performs postflight logic that happens after
+// controller reconciliation is performed.
+func {{ .Resource.Kind }}PostFlight(
+	reconciler common.ComponentReconciler,
+) (ready bool, err error) {
+	return true, nil
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/precreate/component.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/precreate/component.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package precreate
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
+)
+
+var _ machinery.Template = &Component{}
+
+// Component scaffolds the workload's precreate function.
+type Component struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+	machinery.ResourceMixin
+}
+
+func (f *Component) SetTemplateDefaults() error {
+	f.Path = filepath.Join(
+		"internal",
+		"precreate",
+		fmt.Sprintf("%s.go", utils.ToFileName(f.Resource.Kind)),
+	)
+
+	f.TemplateBody = componentTemplate
+
+	return nil
+}
+
+const componentTemplate = `{{ .Boilerplate }}
+
+package precreate
+
+import (
+	"{{ .Repo }}/apis/common"
+)
+
+// {{ .Resource.Kind }}PreCreate performs precreate logic that happens prior to
+// any resource creation is performed.
+func {{ .Resource.Kind }}PreCreate(
+	reconciler common.ComponentReconciler,
+) (ready bool, err error) {
+	return true, nil
+}
+`

--- a/internal/plugins/workload/v1/scaffolds/templates/int/preflight/component.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/int/preflight/component.go
@@ -1,0 +1,52 @@
+// Copyright 2021 VMware, Inc.
+// SPDX-License-Identifier: MIT
+
+package preflight
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
+
+	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
+)
+
+var _ machinery.Template = &Component{}
+
+// Component scaffolds the workload's preflight function.
+type Component struct {
+	machinery.TemplateMixin
+	machinery.BoilerplateMixin
+	machinery.RepositoryMixin
+	machinery.ResourceMixin
+}
+
+func (f *Component) SetTemplateDefaults() error {
+	f.Path = filepath.Join(
+		"internal",
+		"preflight",
+		fmt.Sprintf("%s.go", utils.ToFileName(f.Resource.Kind)),
+	)
+
+	f.TemplateBody = componentTemplate
+
+	return nil
+}
+
+const componentTemplate = `{{ .Boilerplate }}
+
+package preflight
+
+import (
+	"{{ .Repo }}/apis/common"
+)
+
+// {{ .Resource.Kind }}PreFlight performs preflight logic that happens prior to
+// any controller reconciliation is performed.
+func {{ .Resource.Kind }}PreFlight(
+	reconciler common.ComponentReconciler,
+) (ready bool, err error) {
+	return true, nil
+}
+`


### PR DESCRIPTION
The following phases are added to controller reconciliation and are stubbed out in order to allow consumers to add their own custom, generic logic to controller reconciliation:

- PreFlight - happens before reconciliation happens
- PostFlight - happens after reconciliation happens
- PreCreate - happens before resource creation
- PostCreate - happens after resource creation

Signed-off-by: Dustin Scott <sdustin@vmware.com>