### PR TITLE
fix: fixes #95 correct plural names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,12 +9,12 @@
 		"args": [
 			"init",
 			"--workload-config",
-			"${workspaceFolder}/test/platform/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/platform/.workloadConfig/workload.yaml",
 			"--repo",
 			"github.com/acme/acme-cnp-mgr",
 			"--skip-go-version-check"
 		],
-		"cwd": "${workspaceFolder}/test/platform",
+		"cwd": "${workspaceFolder}/test/cases/platform",
 	},
 	{
 		"name": "Test Platform Create",
@@ -26,11 +26,11 @@
 			"create",
 			"api",
 			"--workload-config",
-			"${workspaceFolder}/test/platform/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/platform/.workloadConfig/workload.yaml",
 			"--controller",
 			"--resource"
 		],
-		"cwd": "${workspaceFolder}/test/platform",
+		"cwd": "${workspaceFolder}/test/cases/platform",
 	},
 	{
 		"name": "Test Edge Standalone Init",
@@ -41,12 +41,12 @@
 		"args": [
 			"init",
 			"--workload-config",
-			"${workspaceFolder}/test/edge-standalone/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/edge-standalone/.workloadConfig/workload.yaml",
 			"--repo",
 			"github.com/acme/acme-cnp-mgr",
 			"--skip-go-version-check"
 		],
-		"cwd": "${workspaceFolder}/test/edge-standalone",
+		"cwd": "${workspaceFolder}/test/cases/edge-standalone",
 	},
 	{
 		"name": "Test Edge Standalone Create",
@@ -58,11 +58,11 @@
 			"create",
 			"api",
 			"--workload-config",
-			"${workspaceFolder}/test/edge-standalone/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/edge-standalone/.workloadConfig/workload.yaml",
 			"--controller",
 			"--resource"
 		],
-		"cwd": "${workspaceFolder}/test/edge-standalone",
+		"cwd": "${workspaceFolder}/test/cases/edge-standalone",
 	},
 	{
 		"name": "Test Edge Collection Init",
@@ -73,12 +73,12 @@
 		"args": [
 			"init",
 			"--workload-config",
-			"${workspaceFolder}/test/edge-collection/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/edge-collection/.workloadConfig/workload.yaml",
 			"--repo",
 			"github.com/acme/acme-cnp-mgr",
 			"--skip-go-version-check"
 		],
-		"cwd": "${workspaceFolder}/test/edge-collection",
+		"cwd": "${workspaceFolder}/test/cases/edge-collection",
 	},
 	{
 		"name": "Test Edge Collection Create",
@@ -90,11 +90,11 @@
 			"create",
 			"api",
 			"--workload-config",
-			"${workspaceFolder}/test/edge-collection/.workloadConfig/workload.yaml",
+			"${workspaceFolder}/test/cases/edge-collection/.workloadConfig/workload.yaml",
 			"--controller",
 			"--resource"
 		],
-		"cwd": "${workspaceFolder}/test/edge-collection",
+		"cwd": "${workspaceFolder}/test/cases/edge-collection",
 	},
 ]
 }

--- a/internal/plugins/config/v1/api.go
+++ b/internal/plugins/config/v1/api.go
@@ -71,4 +71,3 @@ func (p *createAPISubcommand) InjectResource(res *resource.Resource) error {
 func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 	return nil
 }
-

--- a/internal/plugins/workload/v1/scaffolds/api.go
+++ b/internal/plugins/workload/v1/scaffolds/api.go
@@ -5,7 +5,6 @@ package scaffolds
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/spf13/afero"
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
@@ -81,8 +80,6 @@ func (s *apiScaffolder) Scaffold() error {
 	)
 
 	createFuncNames, initFuncNames := s.workload.GetFuncNames()
-
-	var crdSampleFilenames []string
 
 	// companion CLI
 	if s.workload.IsStandalone() && s.workload.GetRootcommandName() != "" {
@@ -261,16 +258,6 @@ func (s *apiScaffolder) Scaffold() error {
 		}
 	} else {
 		// collection API
-		crdSampleFilenames = append(
-			crdSampleFilenames,
-			strings.ToLower(fmt.Sprintf(
-				"%s.%s_%s.yaml",
-				s.workload.GetAPIGroup(),
-				s.workload.GetDomain(),
-				utils.PluralizeKind(s.workload.GetAPIKind()),
-			)),
-		)
-
 		err = scaffold.Execute(
 			&templates.MainUpdater{
 				WireResource:   true,
@@ -335,9 +322,7 @@ func (s *apiScaffolder) Scaffold() error {
 			&samples.CRDSample{
 				SpecFields: s.workload.GetAPISpecFields(),
 			},
-			&crd.Kustomization{
-				CRDSampleFilenames: crdSampleFilenames,
-			},
+			&crd.Kustomization{},
 		)
 		if err != nil {
 			return err
@@ -355,16 +340,6 @@ func (s *apiScaffolder) Scaffold() error {
 			)
 
 			createFuncNames, initFuncNames := component.GetFuncNames()
-
-			crdSampleFilenames = append(
-				crdSampleFilenames,
-				strings.ToLower(fmt.Sprintf(
-					"%s.%s_%s.yaml",
-					component.GetAPIGroup(),
-					s.workload.GetDomain(),
-					utils.PluralizeKind(component.GetAPIKind()),
-				)),
-			)
 
 			err = componentScaffold.Execute(
 				&templates.MainUpdater{
@@ -401,9 +376,7 @@ func (s *apiScaffolder) Scaffold() error {
 				&samples.CRDSample{
 					SpecFields: component.Spec.APISpecFields,
 				},
-				&crd.Kustomization{
-					CRDSampleFilenames: crdSampleFilenames,
-				},
+				&crd.Kustomization{},
 			)
 			if err != nil {
 				return err

--- a/internal/plugins/workload/v1/scaffolds/templates/config/crd/kustomization.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/config/crd/kustomization.go
@@ -4,50 +4,109 @@
 package crd
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"sigs.k8s.io/kubebuilder/v3/pkg/machinery"
 )
 
-var _ machinery.Template = &Kustomization{}
+var (
+	_ machinery.Template = &Kustomization{}
+	_ machinery.Inserter = &Kustomization{}
+)
 
-// Kustomization scaffolds the CRD kustomization.yaml file.
+// Kustomization scaffolds a file that defines the kustomization scheme for the crd folder
 type Kustomization struct {
 	machinery.TemplateMixin
 	machinery.ResourceMixin
-
-	CRDSampleFilenames []string
 }
 
+// SetTemplateDefaults implements file.Template
 func (f *Kustomization) SetTemplateDefaults() error {
-	f.Path = filepath.Join("config", "crd", "kustomization.yaml")
-	f.TemplateBody = kustomizationTemplate
-	f.IfExistsAction = machinery.OverwriteFile
+	if f.Path == "" {
+		f.Path = filepath.Join("config", "crd", "kustomization.yaml")
+	}
+	f.Path = f.Resource.Replacer().Replace(f.Path)
+
+	f.TemplateBody = fmt.Sprintf(kustomizationTemplate,
+		machinery.NewMarkerFor(f.Path, resourceMarker),
+		machinery.NewMarkerFor(f.Path, webhookPatchMarker),
+		machinery.NewMarkerFor(f.Path, caInjectionPatchMarker),
+	)
 
 	return nil
 }
 
-const kustomizationTemplate = `# This kustomization.yaml is not intended to be run by itself,
+const (
+	resourceMarker         = "crdkustomizeresource"
+	webhookPatchMarker     = "crdkustomizewebhookpatch"
+	caInjectionPatchMarker = "crdkustomizecainjectionpatch"
+)
+
+// GetMarkers implements file.Inserter
+func (f *Kustomization) GetMarkers() []machinery.Marker {
+	return []machinery.Marker{
+		machinery.NewMarkerFor(f.Path, resourceMarker),
+		machinery.NewMarkerFor(f.Path, webhookPatchMarker),
+		machinery.NewMarkerFor(f.Path, caInjectionPatchMarker),
+	}
+}
+
+const (
+	resourceCodeFragment = `- bases/%s_%s.yaml
+`
+	webhookPatchCodeFragment = `#- patches/webhook_in_%s.yaml
+`
+	caInjectionPatchCodeFragment = `#- patches/cainjection_in_%s.yaml
+`
+)
+
+// GetCodeFragments implements file.Inserter
+func (f *Kustomization) GetCodeFragments() machinery.CodeFragmentsMap {
+	fragments := make(machinery.CodeFragmentsMap, 3)
+
+	// Generate resource code fragments
+	res := make([]string, 0)
+	res = append(res, fmt.Sprintf(resourceCodeFragment, f.Resource.QualifiedGroup(), f.Resource.Plural))
+
+	// Generate resource code fragments
+	webhookPatch := make([]string, 0)
+	webhookPatch = append(webhookPatch, fmt.Sprintf(webhookPatchCodeFragment, f.Resource.Plural))
+
+	// Generate resource code fragments
+	caInjectionPatch := make([]string, 0)
+	caInjectionPatch = append(caInjectionPatch, fmt.Sprintf(caInjectionPatchCodeFragment, f.Resource.Plural))
+
+	// Only store code fragments in the map if the slices are non-empty
+	if len(res) != 0 {
+		fragments[machinery.NewMarkerFor(f.Path, resourceMarker)] = res
+	}
+	if len(webhookPatch) != 0 {
+		fragments[machinery.NewMarkerFor(f.Path, webhookPatchMarker)] = webhookPatch
+	}
+	if len(caInjectionPatch) != 0 {
+		fragments[machinery.NewMarkerFor(f.Path, caInjectionPatchMarker)] = caInjectionPatch
+	}
+
+	return fragments
+}
+
+var kustomizationTemplate = `# This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-{{ range .CRDSampleFilenames -}}
-- bases/{{ . }}
-{{ end }}
+%s
 
 patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_cloudnativeplatforms.yaml
-#+kubebuilder:scaffold:crdkustomizewebhookpatch
+%s
 
-# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_cloudnativeplatforms.yaml
-#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+%s
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
 `
-

--- a/internal/utils/names.go
+++ b/internal/utils/names.go
@@ -5,8 +5,6 @@ package utils
 
 import (
 	"strings"
-
-	pluralize "github.com/gertd/go-pluralize"
 )
 
 // ToPascalCase will convert a kebab-case string to a PascalCase name appropriate to
@@ -43,11 +41,3 @@ func ToFileName(name string) string {
 func ToPackageName(name string) string {
 	return strings.ToLower(strings.Replace(name, "-", "", -1))
 }
-
-// PluralizeKind returns the plural version of a kind in lowercase.
-func PluralizeKind(kind string) string {
-	p := pluralize.NewClient()
-
-	return strings.ToLower(p.Plural(kind))
-}
-

--- a/internal/workload/v1/component.go
+++ b/internal/workload/v1/component.go
@@ -173,7 +173,7 @@ func (c *ComponentWorkload) GetComponentResource(domain, repo string, clusterSco
 			Version: c.Spec.API.Version,
 			Kind:    c.Spec.API.Kind,
 		},
-		Plural: utils.PluralizeKind(c.Spec.API.Kind),
+		Plural: resource.RegularPlural(c.Spec.API.Kind),
 		Path: fmt.Sprintf(
 			"%s/apis/%s/%s",
 			repo,

--- a/internal/workload/v1/rbac.go
+++ b/internal/workload/v1/rbac.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/vmware-tanzu-labs/operator-builder/internal/utils"
+	"sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 )
 
 func (rule *RBACRule) AddVerb(verb string) {
@@ -80,7 +80,7 @@ func getResourceForRBAC(kind string) string {
 	if rbacResource[0] == "*" {
 		kind = "*"
 	} else {
-		kind = utils.PluralizeKind(rbacResource[0])
+		kind = resource.RegularPlural(rbacResource[0])
 	}
 
 	if len(rbacResource) > 1 {
@@ -157,4 +157,3 @@ func rbacRulesForManifest(kind, group string, rawContent interface{}, rbacRules 
 		}
 	}
 }
-

--- a/test/cases/edge-collection/.workloadConfig/ingress/contour-component.yaml
+++ b/test/cases/edge-collection/.workloadConfig/ingress/contour-component.yaml
@@ -1,10 +1,13 @@
-name: contour-component
+# test:
+#   ending name with "two" fails
+#   see https://github.com/vmware-tanzu-labs/operator-builder/issues/95
+name: contour-component-two
 kind: ComponentWorkload
 spec:
   api:
     group: ingress
     version: v1alpha1
-    kind: Contour
+    kind: ContourTwo
     clusterScoped: true
   companionCliSubcmd:
     name: contour


### PR DESCRIPTION
This PR does the following:

- Use `RegularPlural` method from kubebuilder resources package which correctly pluralizes the name.
- The above also fixes an RBAC marker bug that we have not run into yet.
- Remove the internal `Pluralize` method which incorrectly pluralizes resource names.
- Adjust test cases.