### PR TITLE
fix: add prereq section in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ The custom resource defined in the source code can be cluster-scoped or
 namespace-scoped based on the requirements of the project.  More info
 [here](docs/resource-scope.md).
 
+## Prerequisites
+
+- Go version 1.16 or later
+- Make
+- Docker (for building/pushing controller images)
+
 ## Installation
 
 Get the source code.
@@ -428,4 +434,3 @@ info [here](docs/license.md).
 ## Testing
 
 Testing of Operator Builder is documented [here](docs/testing.md).
-


### PR DESCRIPTION
This simply adds a prerequisite section in the README in the
root of the repo.  It should be noted that go >= 1.16 is
required due to some of the underlying packages that we
use requiring its use (specifically the io/fs package
which is imported by multiple package and also directly used
in the license plugin).

Signed-off-by: Dustin Scott <sdustin@vmware.com>