### PR TITLE
fix: change platofrm test storage class name

### DIFF
--- a/test/cases/platform/.workloadConfig/storage-class.yaml
+++ b/test/cases/platform/.workloadConfig/storage-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: standard
+  name: opb-aws-test
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2


### PR DESCRIPTION
The test storage class name was "standard."  If there's an existing
storage class in the test cluster with that name, it will throw errors
in the controller.  It's a common name for a storage class so changed it
to something unusual.

Signed-off-by: Richard Lander <lander2k2@protonmail.com>