### PR TITLE
fix: only generate build-cli docs with companion cli

### DIFF
--- a/internal/plugins/workload/v1/scaffolds/templates/readme.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/readme.go
@@ -69,6 +69,7 @@ To clean up:
 
     make undeploy
 
+{{ if ne .RootCmd "" -}}
 ## Companion CLI
 
 To build the companion CLI:
@@ -79,4 +80,5 @@ The CLI binary will get saved to the bin directory.  You can see the help
 message with:
 
     ./bin/{{ .RootCmd }} help
+{{ end -}}
 `


### PR DESCRIPTION
Signed-off-by: Dustin Scott <sdustin@vmware.com>