### PR TITLE
fix: fixes #193 fix incorrect pluralization for resourcequota

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1153,8 +1153,6 @@ sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPh
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
 sigs.k8s.io/kubebuilder/v3 v3.0.0 h1:jCXjBl04Dd2anjv9aZQwayqu7ibPeHm2iSxPOGkzmpc=
 sigs.k8s.io/kubebuilder/v3 v3.0.0/go.mod h1:KJLAKkOvgXZ2+1REJqFmoseez1tgg5Qoz0zFeJorrSo=
-sigs.k8s.io/kubebuilder/v3 v3.1.0 h1:LPgQQcKtVwqJ19gRboBYJHRG9a/wDeP3fXO7czTKVwE=
-sigs.k8s.io/kubebuilder/v3 v3.1.0/go.mod h1:kWdZWaDD6/+IEU+fX9OH6yD8XjEHBvgfcd8WjjJ9qDo=
 sigs.k8s.io/kustomize/kyaml v0.10.10 h1:caAxDDkaXZp+0kDsZVik4leFJV8LCy09PdVqpaoNeF4=
 sigs.k8s.io/kustomize/kyaml v0.10.10/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/internal/workload/v1/rbac.go
+++ b/internal/workload/v1/rbac.go
@@ -103,7 +103,7 @@ func getResourceForRBAC(kind string) string {
 	if rbacResource[0] == "*" {
 		kind = "*"
 	} else {
-		kind = resource.RegularPlural(rbacResource[0])
+		kind = getPluralRBAC(rbacResource[0])
 	}
 
 	if len(rbacResource) > 1 {
@@ -111,6 +111,21 @@ func getResourceForRBAC(kind string) string {
 	}
 
 	return kind
+}
+
+// getPluralRBAC will transform known irregulars into a proper type for rbac
+// rules.
+func getPluralRBAC(kind string) string {
+	pluralMap := map[string]string{
+		"resourcequota": "resourcequotas",
+	}
+	plural := resource.RegularPlural(kind)
+
+	if pluralMap[plural] != "" {
+		return pluralMap[plural]
+	}
+
+	return plural
 }
 
 func valueFromInterface(in interface{}, key string) (out interface{}) {

--- a/test/cases/edge-standalone/.workloadConfig/resources.yaml
+++ b/test/cases/edge-standalone/.workloadConfig/resources.yaml
@@ -46,3 +46,14 @@ spec:
   - protocol: TCP
     port: 80
     targetPort: 8080
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+spec:
+  hard:
+    requests.cpu: "4"
+    requests.memory: 4Gi
+    limits.cpu: "4"
+    limits.memory: 4Gi


### PR DESCRIPTION
This commit adds a map to translate known irregular plural types
to their proper types such that RBAC markers for kubebuilder and
controller-gen can properly generate the RBAC.  The first type
to fail this was a resourcequota but I expect there to be more
as we find them.  To fix this in the future, we will need to add
the translations into the map.

Signed-off-by: Dustin Scott <sdustin@vmware.com>