### PR TITLE
fix: return nil instead of an error

### DIFF
--- a/internal/plugins/workload/v1/scaffolds/templates/controller/controller.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/controller/controller.go
@@ -91,7 +91,6 @@ type {{ .Resource.Kind }}Reconciler struct {
 	{{ end }}
 }
 
-
 func New{{ .Resource.Kind }}Reconciler(mgr ctrl.Manager) *{{ .Resource.Kind }}Reconciler {
 	return &{{ .Resource.Kind }}Reconciler{
 		Name:      "{{ .Resource.Kind }}",
@@ -133,7 +132,7 @@ func (r *{{ .Resource.Kind }}Reconciler) Reconcile(ctx context.Context, req ctrl
 
 		log.V(0).Info("unable to fetch {{ .Resource.Kind }}")
 
-		return ctrl.Result{}, fmt.Errorf("resource not found, %w", err)
+		return ctrl.Result{}, nil
 	}
 
 	{{ if .IsComponent }}


### PR DESCRIPTION
This addresses a problem in which an error is always returned
even in the case when the parent resource cannot be found.  In the
past, a resource not found would return a nil error, while any
other error would return the error.  Removed the situation where
an error is always returned.

Signed-off-by: Dustin Scott <sdustin@vmware.com>