### PR TITLE
feat: fixes #192 add default values to doc comments

### DIFF
--- a/internal/workload/v1/api.go
+++ b/internal/workload/v1/api.go
@@ -221,6 +221,7 @@ func (api *APIFields) setDefault(sampleVal interface{}, hasDefault bool) {
 				api.Markers,
 				fmt.Sprintf("+kubebuilder:default=%s", api.Default),
 				"+kubebuilder:validation:Optional",
+				fmt.Sprintf("(Default: %s)", api.Default),
 			)
 		}
 


### PR DESCRIPTION
The following will always add default values into the documentation comments, such that the `kubectl explain` command will always list what the default value is.  Below is an example of what is generated from the standalone test:

```bash
sdustin-a01:operator-builder-testing sdustin$ kubectl explain webstores.spec.webstore.really.long.path
KIND:     WebStore
VERSION:  apps.acme.com/v1alpha1

RESOURCE: path <Object>

DESCRIPTION:
     <empty>

FIELDS:
   image        <string>
     (Default: "nginx:1.17") Defines the web store image
```

Signed-off-by: Dustin Scott <sdustin@vmware.com>