### PR TITLE
test: multi-api version and multi-component testing

### DIFF
--- a/.github/common-actions/e2e-test/action.yaml
+++ b/.github/common-actions/e2e-test/action.yaml
@@ -79,8 +79,8 @@ runs:
         # TODO: this is temporary to ensure we test the reconciliation loop
         # for our test workloads.  the end goal would be to genericize this
         # to ensure we can test any workload.
-        if [[ -f .workloadConfig/v1alpha1_workloads_test.go.test ]]; then
-          cp .workloadConfig/v1alpha1_workloads_test.go.test test/e2e/v1alpha1_workloads_test.go
+        if [[ -f .workloadConfig/apps_v1alpha1_webstore_test.go.test ]]; then
+          cp .workloadConfig/apps_v1alpha1_webstore_test.go.test test/e2e/apps_v1alpha1_webstore_test.go
         fi
 
         # run the e2e tests

--- a/.github/common-actions/e2e-test/action.yaml
+++ b/.github/common-actions/e2e-test/action.yaml
@@ -35,7 +35,7 @@ runs:
 
     - name: Setup KIND Cluster
       shell: bash
-      run: kind create cluster --name operator-builder-test
+      run: kind create cluster --name operator-builder-test --config test/cases/default/kind-config.yaml
 
     - name: Install Custom Resources
       shell: bash

--- a/internal/plugins/workload/v1/scaffolds/api.go
+++ b/internal/plugins/workload/v1/scaffolds/api.go
@@ -6,6 +6,7 @@ package scaffolds
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/spf13/afero"
 	"sigs.k8s.io/kubebuilder/v3/pkg/config"
@@ -369,29 +370,12 @@ func (s *apiScaffolder) scaffoldE2ETests(
 	scaffold *machinery.Scaffold,
 	workload workloadv1.WorkloadAPIBuilder,
 ) error {
-	e2eWorkloadBuilder := &e2e.WorkloadTestUpdater{
-		HasChildResources: workload.HasChildResources(),
-		IsStandalone:      workload.IsStandalone(),
-		IsComponent:       workload.IsComponent(),
-		IsCollection:      workload.IsCollection(),
-		PackageName:       workload.GetPackageName(),
-		IsClusterScoped:   workload.IsClusterScoped(),
+	if err := scaffold.Execute(&e2e.WorkloadTest{Builder: workload}); err != nil {
+		return fmt.Errorf("error updating test/e2e/%s_%s_%s_test.go; %w",
+			workload.GetAPIGroup(), workload.GetAPIVersion(), strings.ToLower(workload.GetAPIKind()),
+			err,
+		)
 	}
 
-	if !s.workload.IsStandalone() {
-		collection, ok := s.workload.(*workloadv1.WorkloadCollection)
-		if !ok {
-			//nolint: goerr113
-			return fmt.Errorf("unable to convert workload to collection")
-		}
-
-		e2eWorkloadBuilder.Collection = collection
-	}
-
-	//nolint: wrapcheck
-	return scaffold.Execute(
-		&e2e.Test{},
-		&e2e.WorkloadTest{},
-		e2eWorkloadBuilder,
-	)
+	return nil
 }

--- a/internal/plugins/workload/v1/scaffolds/init.go
+++ b/internal/plugins/workload/v1/scaffolds/init.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates"
 	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/cli"
+	"github.com/vmware-tanzu-labs/operator-builder/internal/plugins/workload/v1/scaffolds/templates/test/e2e"
 	workloadv1 "github.com/vmware-tanzu-labs/operator-builder/internal/workload/v1"
 )
 
@@ -90,6 +91,7 @@ func (s *initScaffolder) Scaffold() error {
 		&templates.Dockerfile{},
 		&templates.Makefile{RootCmdName: s.cliRootCommandName},
 		&templates.Readme{RootCmdName: s.cliRootCommandName},
+		&e2e.Test{},
 	); err != nil {
 		return fmt.Errorf("unable to scaffold initial configuration, %w", err)
 	}

--- a/internal/plugins/workload/v1/scaffolds/templates/test/e2e/e2e.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/test/e2e/e2e.go
@@ -35,8 +35,10 @@ const e2eTestTemplate = `//go:build e2e_test
 package e2e_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -47,6 +49,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gopkg.in/yaml.v2"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	k8syaml "sigs.k8s.io/yaml"
@@ -54,6 +57,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
 
@@ -104,6 +108,7 @@ type E2ETest struct {
 	collectionTester   *E2ETest
 	children           []client.Object
 	getChildrenFunc    getChildren
+	logSyntax          string
 }
 
 type getChildren func(*E2ETest) error
@@ -153,6 +158,9 @@ func TestMain(t *testing.T) {
 	// teardown the test suites
 	componentSuite.teardown()
 	collectionSuite.teardown()
+
+	// check all controller logs for errors
+	require.NoErrorf(t, testControllerLogsNoErrors(e2eTestSuite, ""), "found errors in controller logs")
 
 	// perform final teardown
 	require.NoErrorf(t, finalTeardown(), "error tearing down test suite")
@@ -487,6 +495,12 @@ func getClientForResource(tester *E2ETest, resource client.Object) dynamic.Resou
 		Namespace(resource.GetNamespace())
 }
 
+func getControllerDeployment(s *E2ETestSuiteConfig) (*appsv1.Deployment, error) {
+	return s.client.
+		AppsV1().Deployments(s.controllerConfig.Namespace).
+		Get(context.TODO(), (s.controllerConfig.Prefix + controllerName), metav1.GetOptions{})
+}
+
 func createCustomResource(tester *E2ETest) error {
 	_, err := getClientForResource(tester, tester.unstructured).
 		Create(context.TODO(), tester.unstructured, metav1.CreateOptions{})
@@ -522,6 +536,45 @@ func getResource(tester *E2ETest, resource client.Object) (client.Object, error)
 	}
 
 	return clusterObject, nil
+}
+
+func getControllerLogs(s *E2ETestSuiteConfig) (string, error) {
+	deployment, err := getControllerDeployment(s)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve controller deployment; %w", err)
+	}
+
+	podListOpts := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(deployment.Spec.Template.Labels).String(),
+	}
+
+	controllerPods, err := s.client.CoreV1().Pods(s.controllerConfig.Namespace).List(context.TODO(), podListOpts)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve controller pods; %w", err)
+	}
+
+	buf := new(bytes.Buffer)
+
+	for _, pod := range controllerPods.Items {
+		for _, container := range pod.Spec.Containers {
+			podLogOpts := v1.PodLogOptions{Container: container.Name}
+			req := s.client.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+
+			podLogs, err := req.Stream(context.TODO())
+			if err != nil {
+				return "", fmt.Errorf("error opening log stream for pod %s/%s; %w", pod.Namespace, pod.Name, err)
+			}
+
+			defer podLogs.Close()
+
+			_, err = io.Copy(buf, podLogs)
+			if err != nil {
+				return "", fmt.Errorf("error storing logs to string buffer; %w", err)
+			}
+		}
+	}
+
+	return buf.String(), nil
 }
 
 func updateResource(tester *E2ETest, resource client.Object) error {
@@ -784,6 +837,27 @@ func testUpdateChildResource(tester *E2ETest, childToUpdate, desiredStateChild c
 				err,
 			)
 		}
+	}
+
+	return nil
+}
+
+func testControllerLogsNoErrors(s *E2ETestSuiteConfig, searchSyntax string) error {
+	logs, err := getControllerLogs(s)
+	if err != nil {
+		return fmt.Errorf("failed fetching controller logs; %w", err)
+	}
+
+	errors := []string{}
+
+	for _, logLine := range strings.Split(logs, "\n") {
+		if strings.Contains(logLine, "ERROR") && strings.Contains(logLine, searchSyntax) {
+			errors = append(errors, logLine)
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("found errors in controller: +%v", errors)
 	}
 
 	return nil

--- a/internal/plugins/workload/v1/scaffolds/templates/test/e2e/e2e.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/test/e2e/e2e.go
@@ -63,6 +63,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/nukleros/operator-builder-tools/pkg/resources"
+	"github.com/nukleros/operator-builder-tools/pkg/controller/workload"
 	kbresource "sigs.k8s.io/kubebuilder/v3/pkg/model/resource"
 )
 
@@ -99,7 +100,7 @@ type E2ETest struct {
 	namespace          string
 	sampleManifestFile string
 	unstructured       *unstructured.Unstructured
-	workload           client.Object
+	workload           workload.Workload
 	collectionTester   *E2ETest
 	children           []client.Object
 	getChildrenFunc    getChildren

--- a/internal/plugins/workload/v1/scaffolds/templates/test/e2e/workloads.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/test/e2e/workloads.go
@@ -116,6 +116,7 @@ func {{ .TesterName }}NewHarness(namespace string) *E2ETest {
 		workload:           &{{ .Resource.ImportAlias }}.{{ .Resource.Kind }}{},
 		sampleManifestFile: "{{ .TesterSamplePath }}",
 		getChildrenFunc:    {{ .TesterName }}ChildrenFuncs,
+		logSyntax:          "controllers.{{ .Resource.Group }}.{{ .Resource.Kind }}",
 		{{ if .Builder.IsComponent -}}
 		collectionTester:   {{ .TesterCollectionName }}NewHarness("{{ .TesterCollectionNamespace }}"),     
 		{{ end }}
@@ -144,6 +145,9 @@ func (tester *E2ETest) {{ .TesterName }}Test(testSuite *E2EComponentTestSuite) {
 	// test the update of a parent object
 	// TODO: need immutable fields so that we can predict which managed fields we can modify to test reconciliation
 	// see https://github.com/vmware-tanzu-labs/operator-builder/issues/67
+
+	// test that controller logs do not contain errors
+	require.NoErrorf(testSuite.T(), testControllerLogsNoErrors(tester.suiteConfig, tester.logSyntax), "found errors in controller logs")
 }
 
 {{ if .Builder.IsCollection -}}

--- a/test/cases/application/.workloadConfig/v1alpha1_workloads_test.go.test
+++ b/test/cases/application/.workloadConfig/v1alpha1_workloads_test.go.test
@@ -11,14 +11,12 @@ import (
 
 	"github.com/nukleros/operator-builder-tools/pkg/resources"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	appsv1alpha1 "github.com/acme/acme-cnp-mgr/apis/apps/v1alpha1"
 	"github.com/acme/acme-cnp-mgr/apis/apps/v1alpha1/webstore"
-	//+kubebuilder:scaffold:operator-builder:imports
 )
 
 //
@@ -26,42 +24,37 @@ import (
 //
 func appsv1alpha1WebStoreChildrenFuncs(tester *E2ETest) error {
 	// TODO: need to run r.GetResources(request) on the reconciler to get the mutated resources
-	tester.children = make([]client.Object, len(webstore.CreateFuncs))
-
-	if len(tester.children) == 0 {
+	if len(webstore.CreateFuncs) == 0 {
 		return nil
 	}
 
-	workload, ok := tester.workload.(*appsv1alpha1.WebStore)
-	if !ok {
-		return fmt.Errorf("could not convert metav1.Object to appsv1alpha1.WebStore")
+	workload, err := webstore.ConvertWorkload(tester.workload)
+	if err != nil {
+		return fmt.Errorf("error in workload conversion; %w", err)
 	}
 
-	for i, f := range webstore.CreateFuncs {
-		resource, err := f(workload)
-		if err != nil {
-			return fmt.Errorf("unable to create object in memory; %s", err)
-		}
-
-		tester.children[i] = resource.(client.Object)
+	resourceObjects, err := webstore.Generate(*workload)
+	if err != nil {
+		return fmt.Errorf("unable to create objects in memory; %w", err)
 	}
+
+	tester.children = resourceObjects
 
 	return nil
 }
 
-func appsv1alpha1WebStoreTest() *E2ETest {
+func appsv1alpha1WebStoreNewHarness(namespace string) *E2ETest {
 	return &E2ETest{
-		namespace:          "test-apps-v1alpha1-webstore",
+		namespace:          namespace,
 		unstructured:       &unstructured.Unstructured{},
 		workload:           &appsv1alpha1.WebStore{},
 		sampleManifestFile: "../../config/samples/apps_v1alpha1_webstore.yaml",
 		getChildrenFunc:    appsv1alpha1WebStoreChildrenFuncs,
+		logSyntax:          "controllers.apps.WebStore",
 	}
 }
 
-func (testSuite *E2EComponentTestSuite) Test_appsv1alpha1WebStore() {
-	// setup
-	tester := appsv1alpha1WebStoreTest()
+func (tester *E2ETest) appsv1alpha1WebStoreTest(testSuite *E2EComponentTestSuite) {
 	testSuite.suiteConfig.tests = append(testSuite.suiteConfig.tests, tester)
 	tester.suiteConfig = &testSuite.suiteConfig
 	require.NoErrorf(testSuite.T(), tester.setup(), "failed to setup test")
@@ -120,6 +113,17 @@ func (testSuite *E2EComponentTestSuite) Test_appsv1alpha1WebStore() {
 		testUpdateParentResource(tester, deploymentToUpdate),
 		"failed to reconcile update of a parent resource",
 	)
+
+	// test that controller logs do not contain errors
+	require.NoErrorf(testSuite.T(), testControllerLogsNoErrors(tester.suiteConfig, tester.logSyntax), "found errors in controller logs")
 }
 
-//+kubebuilder:scaffold:operator-builder:testworkloads
+func (testSuite *E2EComponentTestSuite) Test_appsv1alpha1WebStore() {
+	tester := appsv1alpha1WebStoreNewHarness("test-apps-v1alpha1-webstore")
+	tester.appsv1alpha1WebStoreTest(testSuite)
+}
+
+func (testSuite *E2EComponentTestSuite) Test_appsv1alpha1WebStoreMulti() {
+	tester := appsv1alpha1WebStoreNewHarness("test-apps-v1alpha1-webstore-2")
+	tester.appsv1alpha1WebStoreTest(testSuite)
+}

--- a/test/cases/default/kind-config.yaml
+++ b/test/cases/default/kind-config.yaml
@@ -1,0 +1,7 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
The following is corrected with this PR:

- Fixes #222 which is a bug when generating tests for multiple versions.  Moved this into group_version_kind_test.go logic to make consistent with other files such as `config/samples`
- Fixes #213 which adds a test to ensure that multiple non-cluster scoped, non-collection workloads can be deployed to a cluster
- Fixes #214 which adds a test to ensure that controller logging does not contain any errors, both during collection/component deployment and after