### PR TITLE
refactor: small changes to decode workload kind

### DIFF
--- a/internal/workload/v1/config.go
+++ b/internal/workload/v1/config.go
@@ -243,26 +243,11 @@ func parseCollectionComponents(workload *WorkloadCollection, workloadConfig stri
 func decodeKind(kind WorkloadKind, dc *yaml.Decoder) (WorkloadIdentifier, error) {
 	switch kind {
 	case WorkloadKindStandalone:
-		v := &StandaloneWorkload{}
-		if err := dc.Decode(v); err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-
-		return v, nil
+		return decodeStandalone(dc)
 	case WorkloadKindComponent:
-		v := &ComponentWorkload{}
-		if err := dc.Decode(v); err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-
-		return v, nil
+		return decodeComponent(dc)
 	case WorkloadKindCollection:
-		v := &WorkloadCollection{}
-		if err := dc.Decode(v); err != nil {
-			return nil, fmt.Errorf("%w", err)
-		}
-
-		return v, nil
+		return decodeCollection(dc)
 	default:
 		return nil, fmt.Errorf(
 			"%w - valid kinds: %s, %s, %s,",

--- a/internal/workload/v1/kind.go
+++ b/internal/workload/v1/kind.go
@@ -5,6 +5,7 @@ package v1
 
 import (
 	"errors"
+	"fmt"
 
 	"gopkg.in/yaml.v3"
 )
@@ -33,13 +34,7 @@ func (wk WorkloadKind) String() string {
 }
 
 func (wk *WorkloadKind) UnmarshalJSON(data []byte) error {
-	kinds := map[string]WorkloadKind{
-		"StandaloneWorkload": WorkloadKindStandalone,
-		"WorkloadCollection": WorkloadKindCollection,
-		"ComponentWorkload":  WorkloadKindComponent,
-	}
-
-	kind, ok := kinds[string(data)]
+	kind, ok := workloadKindsMap()[string(data)]
 	if !ok {
 		return ErrInvalidKind
 	}
@@ -50,13 +45,7 @@ func (wk *WorkloadKind) UnmarshalJSON(data []byte) error {
 }
 
 func (wk *WorkloadKind) UnmarshalYAML(node *yaml.Node) error {
-	kinds := map[string]WorkloadKind{
-		"StandaloneWorkload": WorkloadKindStandalone,
-		"WorkloadCollection": WorkloadKindCollection,
-		"ComponentWorkload":  WorkloadKindComponent,
-	}
-
-	kind, ok := kinds[node.Value]
+	kind, ok := workloadKindsMap()[node.Value]
 	if !ok {
 		return ErrInvalidKind
 	}
@@ -64,4 +53,39 @@ func (wk *WorkloadKind) UnmarshalYAML(node *yaml.Node) error {
 	*wk = kind
 
 	return nil
+}
+
+func workloadKindsMap() map[string]WorkloadKind {
+	return map[string]WorkloadKind{
+		"StandaloneWorkload": WorkloadKindStandalone,
+		"WorkloadCollection": WorkloadKindCollection,
+		"ComponentWorkload":  WorkloadKindComponent,
+	}
+}
+
+func decodeStandalone(dc *yaml.Decoder) (*StandaloneWorkload, error) {
+	v := &StandaloneWorkload{}
+	if err := dc.Decode(v); err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return v, nil
+}
+
+func decodeCollection(dc *yaml.Decoder) (*WorkloadCollection, error) {
+	v := &WorkloadCollection{}
+	if err := dc.Decode(v); err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return v, nil
+}
+
+func decodeComponent(dc *yaml.Decoder) (*ComponentWorkload, error) {
+	v := &ComponentWorkload{}
+	if err := dc.Decode(v); err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return v, nil
 }


### PR DESCRIPTION
This will allow a user to simply specify all workload types as
simply  and let the attributes of the workload config
identify the type of workload.  This also supports backwards
compatibility with manifests that use the specific workload types.

Signed-off-by: Dustin Scott <sdustin@vmware.com>