### PR TITLE
docs: fix README typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ namespace-scoped based on the requirements of the project.  More info
 
 ## Installation Options
 
-### [Download the latest binary](https://github.com/vmare-tanzu-labs/operator-builder/releases/latest)
+### [Download the latest binary](https://github.com/vmware-tanzu-labs/operator-builder/releases/latest)
 
 ### wget
 Use wget to download the pre-compiled binaries:

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Use wget to download the pre-compiled binaries:
 
 ```bash
 wget https://github.com/vmware-tanzu-labs/operator-builder/releases/download/${VERSION}/${BINARY}.tar.gz -O - |\
-  tar xz && mv ${BINARY} /usr/bin/operator-builder
+  tar xz && sudo mv operator-builder /usr/bin/operator-builder
 ```
 
-For instance, VERSION=v0.3.1 and BINARY=operator-builder_${VERSION}_linux_amd64
+For instance, VERSION=v0.5.0 and BINARY=operator-builder_${VERSION}_Linux_x86_64
 
 ### MacOS / Linux via Homebrew install
 


### PR DESCRIPTION
This PR fixes a typo in the 'latest release' link and the `wget` quickstart instructions.

Signed-off-by: George Goh <georgegohkokleong@gmail.com>