### PR TITLE
fix: if marker uses replace argument set original value to replace value

### DIFF
--- a/internal/workload/v1/markers/collection_field_marker.go
+++ b/internal/workload/v1/markers/collection_field_marker.go
@@ -99,6 +99,12 @@ func (cfm *CollectionFieldMarker) IsForCollection() bool {
 }
 
 func (cfm *CollectionFieldMarker) SetOriginalValue(value string) {
+	if cfm.GetReplaceText() != "" {
+		cfm.originalValue = cfm.GetReplaceText()
+
+		return
+	}
+
 	cfm.originalValue = &value
 }
 

--- a/internal/workload/v1/markers/field_marker.go
+++ b/internal/workload/v1/markers/field_marker.go
@@ -115,6 +115,11 @@ func (fm *FieldMarker) IsForCollection() bool {
 }
 
 func (fm *FieldMarker) SetOriginalValue(value string) {
+	if fm.GetReplaceText() != "" {
+		fm.originalValue = fm.GetReplaceText()
+
+		return
+	}
 	fm.originalValue = &value
 }
 

--- a/internal/workload/v1/markers/field_marker.go
+++ b/internal/workload/v1/markers/field_marker.go
@@ -120,6 +120,7 @@ func (fm *FieldMarker) SetOriginalValue(value string) {
 
 		return
 	}
+
 	fm.originalValue = &value
 }
 


### PR DESCRIPTION
note: this does fix issue completely, still need to resolve if replace text is regex statement
Signed-off-by: Jeff Davis <jeffda@vmware.com>