### PR TITLE
fix: overlapping resource names and improved rbac rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/cases/collection/*
 !test/cases/edge-collection/.workloadConfig/
 !test/cases/edge-standalone/.workloadConfig/
 !test/cases/collection/.workloadConfig/
+**/*.log

--- a/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
@@ -57,6 +57,11 @@ import (
 )
 
 {{ range .Manifest.ChildResources }}
+{{ range .RBAC }}
+{{- .ToMarker }}
+{{ end -}}
+{{ if ne .NameConstant "" }}const {{ .UniqueName }} = "{{ .NameConstant }}"{{ end }}
+
 // {{ .CreateFuncName }} creates the {{ .Name }} {{ .Kind }} resource.
 func {{ .CreateFuncName }} (
 	parent *{{ $.Resource.ImportAlias }}.{{ $.Resource.Kind }},

--- a/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
+++ b/internal/plugins/workload/v1/scaffolds/templates/api/resources/definition.go
@@ -59,7 +59,7 @@ import (
 {{ range .Manifest.ChildResources }}
 {{ range .RBAC }}
 {{- .ToMarker }}
-{{ end -}}
+{{ end }}
 {{ if ne .NameConstant "" }}const {{ .UniqueName }} = "{{ .NameConstant }}"{{ end }}
 
 // {{ .CreateFuncName }} creates the {{ .Name }} {{ .Kind }} resource.

--- a/internal/workload/v1/kinds/workload.go
+++ b/internal/workload/v1/kinds/workload.go
@@ -244,22 +244,12 @@ func (ws *WorkloadSpec) processManifests(markerTypes ...markers.MarkerType) erro
 				)
 			}
 
-			// add the rules for this manifest
-			rules, err := rbac.ForManifest(&manifestObject)
+			// create the new child resource and validate its unique name
+			childResource, err := manifests.NewChildResource(manifestObject)
 			if err != nil {
-				return processManifestError(
-					fmt.Errorf(
-						"%w; error generating rbac for resource kind [%s] with name [%s]",
-						err, manifestObject.GetKind(), manifestObject.GetName(),
-					),
-					manifestFile,
-				)
+				return processManifestError(err, manifestFile)
 			}
 
-			ws.RBACRules.Add(rules)
-
-			// create the new child resource and validate its unique name
-			childResource := manifests.NewChildResource(manifestObject)
 			if uniqueNames[childResource.UniqueName] {
 				return processManifestError(
 					fmt.Errorf(

--- a/internal/workload/v1/kinds/workload.go
+++ b/internal/workload/v1/kinds/workload.go
@@ -72,7 +72,7 @@ type WorkloadBuilder interface {
 
 var (
 	ErrLoadManifests   = errors.New("error loading manifests")
-	ErrProcessManifest = errors.New("error proessing manifest file")
+	ErrProcessManifest = errors.New("error processing manifest file")
 )
 
 // WorkloadAPISpec contains fields shared by all workload specs.

--- a/internal/workload/v1/rbac/rbac.go
+++ b/internal/workload/v1/rbac/rbac.go
@@ -59,14 +59,14 @@ func knownIrregulars() map[string]string {
 	}
 }
 
-// ForManifest will return a set of rules for a particular manifest.  This includes
-// a rule for the manifest itself, in addition to adding particular rules for whatever
+// ForResource will return a set of rules for a particular kubernetes resource.  This includes
+// a rule for the resource itself, in addition to adding particular rules for whatever
 // roles and cluster roles are requesting.  This is because the controller needs to have
 // permissions to manage the children that roles and cluster roles are requesting.
-func ForManifest(manifest *unstructured.Unstructured) (*Rules, error) {
+func ForResource(manifest *unstructured.Unstructured) (*Rules, error) {
 	rules := &Rules{}
 
-	if err := rules.addForManifest(manifest); err != nil {
+	if err := rules.addForResource(manifest); err != nil {
 		return rules, err
 	}
 

--- a/internal/workload/v1/rbac/rules.go
+++ b/internal/workload/v1/rbac/rules.go
@@ -54,8 +54,8 @@ func (rules *Rules) addForWorkload(workload rbacWorkloadProcessor) {
 	rules.Add(workloadRule, statusRule)
 }
 
-// addForManifest will add a particular rule given an unstructured manifest.
-func (rules *Rules) addForManifest(manifest *unstructured.Unstructured) error {
+// addForResource will add a particular rule given an unstructured manifest.
+func (rules *Rules) addForResource(manifest *unstructured.Unstructured) error {
 	kind := manifest.GetKind()
 
 	rules.Add(

--- a/internal/workload/v1/rbac/rules_internal_test.go
+++ b/internal/workload/v1/rbac/rules_internal_test.go
@@ -284,7 +284,7 @@ func TestRules_addForManifest(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if err := tt.rules.addForManifest(tt.args.manifest); (err != nil) != tt.wantErr {
+			if err := tt.rules.addForResource(tt.args.manifest); (err != nil) != tt.wantErr {
 				t.Errorf("Rules.addForManifest() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			assert.Equal(t, tt.want, tt.rules)

--- a/test/cases/standalone/.workloadConfig/resources.yaml
+++ b/test/cases/standalone/.workloadConfig/resources.yaml
@@ -54,3 +54,18 @@ spec:
     port: 80
     # +operator-builder:field:name=service.targetPort,type=int
     targetPort: 8080
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: webstore-role
+rules:
+  - apiGroups: ["apps"]
+    resources: ["pods", "deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]


### PR DESCRIPTION
This PR addresses the following:

- Ensures uniqueness in resource names for resources contained within input manifests and throws an error when names are not unique (#284)
- Places RBAC rules directly above resources for which they pertain to for more easy auditability for why RBAC is needed as well as to cleanup the giant list of RBAC resources in the controller file (#281)